### PR TITLE
🐛 Fix Markdown output

### DIFF
--- a/templates/template.hbs
+++ b/templates/template.hbs
@@ -1,7 +1,7 @@
 {{> header}}
 {{#each commitGroups}}
 
-{{#if title}}### {{title}}{{/if}}
+{{#if title}}#### {{title}}{{/if}}
 
 {{#each commits}}
 {{> commit}}

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,7 @@ betterThanBefore.setups([
     function() {
         gitDummyCommit([
             '📝(readme) make it clear',
+            '- It does one thing\n- And this other thing',
             'BREAKING CHANGE: The Change is huge.',
         ])
         gitDummyCommit([
@@ -182,6 +183,24 @@ describe('zazen preset', function() {
             )
     })
 
+    it('should maintain indentation for a multi-line commit msg body', function(done) {
+        preparing(5)
+
+        conventionalChangelogCore({ config: preset })
+            .on('error', function(err) {
+                done(err)
+            })
+            .pipe(
+                through(function(chunk) {
+                    chunk = chunk.toString()
+
+                    expect(chunk).to.include('  - And this other thing')
+
+                    done()
+                }),
+            )
+    })
+
     // it('should not discard commit if there is BREAKING CHANGE', function (done) {
     //     preparing(5)
 
@@ -206,7 +225,7 @@ describe('zazen preset', function() {
     //         )
     // })
 
-    it('should BREAKING CHANGES the same as BREAKING CHANGE', function(done) {
+    it('should treat BREAKING CHANGES the same as BREAKING CHANGE', function(done) {
         preparing(6)
 
         conventionalChangelogCore({

--- a/writer-opts.js
+++ b/writer-opts.js
@@ -161,7 +161,14 @@ function getWriterOpts() {
             let commitRefs = commit.references.length
                 ? buildCommitRefs(commit, context)
                 : ''
-            let commitBody = commit.body ? ` \\\n  ${commit.body}` : ''
+
+            /**
+             * Add two spaces before each line of the message body
+             * to maintain Markdown indentation.
+             */
+            let commitBody = commit.body
+                ? ` \\\n${commit.body.replace(/^.*/gm, `  $&`)}`
+                : ''
 
             commit.logString = `- ${currentEmoji}${commitScope} ${commitMsg} ${commitHash}${commitRefs}${commitBody}`
 

--- a/writer-opts.js
+++ b/writer-opts.js
@@ -82,7 +82,9 @@ function getWriterOpts() {
             let headingTitle = context.title ? ` “${context.title}”` : ''
             let headingDate = context.date ? ` — ${context.date}` : ''
 
-            context.releaseTitle = `## ${headingVersion}${headingTitle}${headingDate}`
+            context.releaseTitle = `${
+                context.isPatch ? '###' : '##'
+            } ${headingVersion}${headingTitle}${headingDate}`
 
             return context
         },

--- a/writer-opts.js
+++ b/writer-opts.js
@@ -38,7 +38,7 @@ function buildCommitUrl(commit, context) {
     let urlBase = repository ? `${host}${owner}${repository}` : repoUrl
     let tail = `/${context.commit}/${hash}`
 
-    return `([${hash}](${urlBase}${tail}))`
+    return `[[\`${hash}\`](${urlBase}${tail})]`
 }
 
 function buildCommitRefs(commit, context) {


### PR DESCRIPTION
Updates heading levels (`h2` for major/minor version titles, `h3` for patch titles, `h4` for
commit group headings) and maintains indentation for a multi-line commit message body.

Fixes #1 